### PR TITLE
Fix when no model parameters is present

### DIFF
--- a/src/examples/aligning_readings.py
+++ b/src/examples/aligning_readings.py
@@ -73,7 +73,7 @@ def wait_for_data(samples: int, aligner: Aligner,
 
 from methods import sysid as sysID
 
-def live_align_readings_and_plot(config_path):
+def live_align_readings_plot(config_path):
     number_of_samples = 2560
     
     import numpy as np

--- a/src/examples/example.py
+++ b/src/examples/example.py
@@ -1,7 +1,7 @@
 # pylint: disable=E1120
 import click
 from examples.acceleration_readings import read_accelerometers
-from examples.aligning_readings import (align_acceleration_readings, live_align_readings_and_plot)
+from examples.aligning_readings import (align_acceleration_readings, live_align_readings_plot)
 from examples.run_sysid import (
     run_sysid_and_plot,
     run_sysid_and_publish,
@@ -55,7 +55,7 @@ def align_readings(ctx):
 @cli.command()
 @click.pass_context
 def live_align_readings_and_plot(ctx):
-    live_align_readings_and_plot(ctx.obj["CONFIG"])
+    live_align_readings_plot(ctx.obj["CONFIG"])
 
 @cli.command()
 @click.pass_context

--- a/src/methods/constants.py
+++ b/src/methods/constants.py
@@ -52,9 +52,9 @@ MODEL_PARS_NAME = "beam_pars.jsonl"
 MODEL_FUNC = model.eval_yafem_model
 MODEL_PARAMETERS = {'modes': PARAMS['modes_search_paring'],
             'dofs_sel': np.array([[7,1],[6,1],[5,1],[4,1]]),
-            'k_rot': None, 
+            'k_rot': 1, 
             'l4': 0.1289,
-            'm': None,
+            'm': 0,
             }
 
 

--- a/src/methods/mode_clustering.py
+++ b/src/methods/mode_clustering.py
@@ -171,7 +171,8 @@ def subscribe_and_cluster(config: Dict[str,Any], params: Dict[str,Any]
     mqtt_client, _, __ = start_mqtt(config["mode_cluster"], _on_connect, _on_message=_on_message)
     print("Waiting for sysid data...")
     try:
-        result_ready.wait()  # Wait until message arrives
+        while not result_ready.wait(timeout=2.0):
+            pass  # Keep checking with timeout
         if sysid_output_global is None:
             raise RuntimeError("Failed to receive sysid data.")
 

--- a/src/methods/model_update.py
+++ b/src/methods/model_update.py
@@ -122,7 +122,6 @@ def estimate_updated_model(clusters: Dict[str,Any], model_parameters: Dict[str,A
                                                                     params)
         if omega_model is not None:
             print("Model frequencies:",omega_model,"[Hz]")
-
         return (X, omega_model, updated_model_parameters)
     except Exception as e:
         print('Model update is not succesful.', e)
@@ -201,7 +200,8 @@ def load_model_parameters() -> Optional[Tuple[str, Dict[str,Any]]]:
     try:
         path = Path(MODEL_DIR) / MODEL_PARS_NAME
         if not path.exists():
-            print(f"File not found: {path}. Proceed with standard parameters.")
+            print(f"File not found: {path}. Proceed with standard parameters from model and constants.py..")
+            _, __, ___, ____, _____ = MODEL_FUNC(MODEL_PARAMETERS) #Adds standard model parameters to variable
             model_parameters = MODEL_PARAMETERS
             timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
             return timestamp, model_parameters
@@ -211,9 +211,11 @@ def load_model_parameters() -> Optional[Tuple[str, Dict[str,Any]]]:
             timestamp = data['timestamp']
             model_parameters = data['parameters']
             if model_parameters is None:
-                print("Stored model_parameters are None. Proceed with standard parameters.")
+                print("Stored model_parameters are None. Proceed with standard parameters from model and constants.py.")
+                _, __, ___, ____, _____ = MODEL_FUNC(MODEL_PARAMETERS)
                 model_parameters = MODEL_PARAMETERS
-            print("Model parameters loaded successfully from:", path,"at:", timestamp)
+            else:
+                print("Model parameters loaded successfully from:", path,"at:", timestamp)
 
             return timestamp, model_parameters
     except Exception as e:

--- a/src/methods/virtual_sensing.py
+++ b/src/methods/virtual_sensing.py
@@ -24,7 +24,6 @@ def virtual_sensing(number_of_samples, aligner, data_client, fs):
 
     """
     _, model_parameters = load_model_parameters()
-
     try:
         data, aligner_time = wait_for_data(number_of_samples, aligner, fs)
         try:


### PR DESCRIPTION
Virtual sensing and stress-strain estimation relies on model parameters. When the parameters are missing they use the standard parameters given in the model and constants.py